### PR TITLE
Replace book_detail template page with modals

### DIFF
--- a/bookEx/static/base.css
+++ b/bookEx/static/base.css
@@ -288,6 +288,120 @@ body {
     color: var(--hover-dark-text);
 }
 
+/* modal styling: book detail */
+
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(3px);
+    transition: opacity 0.3s ease;
+}
+
+.modal-content {
+    background-color: var(--card-bg-color);
+    color: var(--text-color-dark);
+    margin: 10% auto;
+    padding: 25px;
+    border: 1px solid var(--input-border-color);
+    width: 80%;
+    max-width: 600px;
+    border-radius: 8px;
+    position: relative;
+    box-shadow: 0 5px 15px var(--shadow-color);
+    transition: background-color var(--transition-speed-fast) ease, color var(--transition-speed-fast) ease, border-color var(--transition-speed-fast) ease;
+}
+
+.close-button {
+    color: #aaa;
+    position: absolute;
+    top: 10px;
+    right: 20px;
+    font-size: 28px;
+    font-weight: bold;
+    transition: color 0.3s ease;
+}
+
+.close-button:hover,
+.close-button:focus {
+    color: var(--text-color-dark);
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.modal-body {
+    display: flex;
+    gap: 20px;
+    margin-top: 15px;
+}
+
+.modal-image {
+    flex-shrink: 0;
+}
+
+.modal-details {
+    flex-grow: 1;
+}
+
+.modal-details p {
+    margin-bottom: 8px;
+    line-height: 1.4;
+}
+
+.modal-details strong {
+    color: var(--text-color-dark);
+    min-width: 80px;
+    display: inline-block;
+}
+
+.modal-content a {
+    color: var(--text-color-light);
+    text-decoration: none;
+}
+
+.modal-content a:hover {
+    background-color: var(--active-hover-bg-color);
+    text-decoration: underline;
+}
+
+body.dark-mode .modal {
+    background-color: rgba(0, 0, 0, 0.7);
+}
+
+
+body.dark-mode .close-button:hover,
+body.dark-mode .close-button:focus {
+    color: var(--text-color-light);
+}
+
+body.dark-mode .modal-details strong {
+    color: var(--text-color-light);
+}
+
+#modalMessages .message {
+    padding: 8px 12px;
+    margin-top: 10px;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+#modalMessages .message.success {
+    background-color: var(--success-bg-color);
+    color: var(--success-color);
+    border: 1px solid var(--success-border-color);
+}
+
+#modalMessages .message.error {
+    background-color: var(--error-bg-color);
+    color: var(--error-color);
+    border: 1px solid var(--error-border-color);
+}
 
 /* main content */
 .home-section {

--- a/bookEx/static/base.css
+++ b/bookEx/static/base.css
@@ -361,19 +361,14 @@ body {
 }
 
 .modal-content a {
-    color: var(--text-color-light);
+    color: var(--text-color-dark);
     text-decoration: none;
-}
-
-.modal-content a:hover {
-    background-color: var(--active-hover-bg-color);
-    text-decoration: underline;
 }
 
 body.dark-mode .modal {
     background-color: rgba(0, 0, 0, 0.7);
+    text-decoration: none;
 }
-
 
 body.dark-mode .close-button:hover,
 body.dark-mode .close-button:focus {
@@ -566,7 +561,12 @@ a.button > i {
     color: var(--text-color-light);
 }
 
-.button-danger:hover {
+body.dark-mode .button:hover {
+    background-color: var(--active-hover-bg-color);
+    color: var(--text-color-light);
+}
+
+.button.button-danger:hover {
     background-color: #c82333;
     border-color: #bd2130;
     color: var(--text-color-light);

--- a/bookEx/static/bookSearch.js
+++ b/bookEx/static/bookSearch.js
@@ -28,8 +28,8 @@ document.addEventListener("DOMContentLoaded", () => {
                         const bookPicture = bookPictureUrl ? `<img src="${bookPictureUrl}" width="100" alt="Cover for ${bookName}"/>` : '';
                         const row = `
                         <tr>
-                             <td><a href="book_detail/${bookId}?from=displaybooks">${bookPicture}</a></td>
-                             <td><a href="book_detail/${bookId}?from=displaybooks">${bookName}</a></td>
+                             <td><a href="#" data-book-id="${bookId}">${bookPicture}</a></td>
+                             <td><a href="#" data-book-id="${bookId}">${bookName}</a></td>
                              <td>${bookPrice}</td>
                              <td>${bookUserName}</td>
                         </tr>

--- a/bookEx/static/modalHandler.js
+++ b/bookEx/static/modalHandler.js
@@ -1,0 +1,203 @@
+const modal = document.getElementById('bookDetailModal');
+const modalTitle = document.getElementById('modalBookTitle');
+const modalImage = document.getElementById('modalBookImage');
+const modalPrice = document.getElementById('modalBookPrice');
+const modalSeller = document.getElementById('modalBookSeller');
+const modalDate = document.getElementById('modalBookDate');
+const modalWebLink = document.getElementById('modalBookWeb');
+const modalActionArea = document.getElementById('modalActionArea');
+const modalMessages = document.getElementById('modalMessages');
+
+function getCsrfToken() {
+    return document.querySelector('[name=csrfmiddlewaretoken]').value;
+}
+
+// status messages like added to cart, etc. clears after timeout
+function showModalMessage(text, type = 'info') {
+    modalMessages.innerHTML = `<div class="message ${type}">${text}</div>`;
+    setTimeout(() => {
+        modalMessages.innerHTML = '';
+    }, 5000);
+}
+
+
+function openModalWithBook(bookId) {
+    if (!modal) return;
+
+    // fallback
+    modalTitle.textContent = 'Loading...';
+    modalImage.src = '';
+    modalPrice.textContent = '...';
+    modalSeller.textContent = '...';
+    modalDate.textContent = '...';
+    modalWebLink.textContent = '...';
+    modalWebLink.href = '#';
+    modalActionArea.innerHTML = '';
+    modalMessages.innerHTML = '';
+    modal.style.display = 'block';
+
+    const url = `/api/book_detail/${bookId}/`;
+
+    fetch(url)
+        .then(response => {
+            if (!response.ok) {
+                return response.json().then(errData => {
+                    throw new Error(errData.error || `HTTP error! Status: ${response.status}`);
+                }).catch(() => {
+                    throw new Error(`HTTP error! Status: ${response.status}`);
+                });
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (data.error) {
+                throw new Error(data.error);
+            }
+            modalTitle.textContent = data.name;
+            modalImage.src = data.picture_url ? data.picture_url : '/static/default_book_cover.png';
+            modalImage.alt = `Cover for ${data.name}`;
+            modalPrice.textContent = data.price;
+            modalSeller.textContent = data.seller;
+            modalDate.textContent = data.publishdate;
+            modalWebLink.textContent = data.web;
+            modalWebLink.href = data.web;
+
+            modalActionArea.innerHTML = '';
+
+            if (data.is_authenticated) {
+                if (data.is_owner) {
+                    if (data.delete_url) {
+                        const deleteForm = document.createElement('form');
+                        deleteForm.method = 'post';
+                        deleteForm.action = data.delete_url;
+                        deleteForm.style.display = 'inline';
+                        deleteForm.onsubmit = function () {
+                            return confirm('Are you sure you want to delete this book? This action cannot be undone.');
+                        };
+
+                        const csrfInput = document.createElement('input');
+                        csrfInput.type = 'hidden';
+                        csrfInput.name = 'csrfmiddlewaretoken';
+                        csrfInput.value = getCsrfToken();
+                        deleteForm.appendChild(csrfInput);
+
+                        const deleteButton = document.createElement('button');
+                        deleteButton.type = 'submit';
+                        deleteButton.className = 'button button-danger'; // Use danger style
+                        deleteButton.innerHTML = '<i class="fas fa-trash-alt"></i> Delete Book';
+                        deleteForm.appendChild(deleteButton);
+
+                        modalActionArea.appendChild(deleteForm);
+                    }
+
+                } else {
+                    const form = document.createElement('form');
+                    form.method = 'post';
+                    form.action = data.add_to_cart_url;
+                    form.style.display = 'inline';
+                    form.addEventListener('submit', handleAddToCart); // Use existing AJAX handler
+
+                    const csrfInput = document.createElement('input');
+                    csrfInput.type = 'hidden';
+                    csrfInput.name = 'csrfmiddlewaretoken';
+                    csrfInput.value = getCsrfToken();
+                    form.appendChild(csrfInput);
+
+                    const button = document.createElement('button');
+                    button.type = 'submit';
+                    button.className = 'button';
+                    button.innerHTML = '<i class="fas fa-cart-plus"></i> Add to Cart';
+                    form.appendChild(button);
+
+                    modalActionArea.appendChild(form);
+                }
+            } else {
+                modalActionArea.innerHTML = `<a href="${data.login_url}" class="button"><i class="fas fa-sign-in-alt"></i> Login to Interact</a>`;
+            }
+        })
+        .catch(error => {
+            console.error('Error fetching book details:', error);
+            modalTitle.textContent = 'Error';
+            modalActionArea.innerHTML = '';
+            showModalMessage(`Could not load book details: ${error.message}`, 'error');
+            modalImage.src = '/static/default_book_cover.png';
+            modalPrice.textContent = 'N/A';
+            modalSeller.textContent = 'N/A';
+            modalDate.textContent = 'N/A';
+            modalWebLink.textContent = 'N/A';
+            modalWebLink.href = '#';
+
+        });
+}
+
+async function handleAddToCart(event) {
+    event.preventDefault();
+    const form = event.target;
+    const url = form.action;
+    const formData = new FormData(form);
+
+    const submitButton = form.querySelector('button[type="submit"]');
+    submitButton.disabled = true;
+    submitButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Adding...';
+    modalMessages.innerHTML = '';
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            body: formData,
+            headers: {
+                'X-CSRFToken': getCsrfToken(),
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data.message || `HTTP error! Status: ${response.status}`);
+        }
+
+
+        if (data.success) {
+            showModalMessage(data.message, 'success');
+        }
+
+    } catch (error) {
+        console.error('Error adding to cart:', error);
+        showModalMessage(`Error: ${error.message}`, 'error');
+    } finally {
+        submitButton.disabled = false;
+        submitButton.innerHTML = '<i class="fas fa-cart-plus"></i> Add to Cart';
+    }
+}
+
+
+function closeModal() {
+    if (modal) {
+        modal.style.display = 'none';
+        modalTitle.textContent = '';
+        modalImage.src = '';
+        modalActionArea.innerHTML = '';
+        modalMessages.innerHTML = '';
+    }
+}
+
+document.addEventListener('click', function (event) {
+    const bookTrigger = event.target.closest('[data-book-id]');
+
+    if (bookTrigger) {
+        event.preventDefault();
+        const bookId = bookTrigger.dataset.bookId;
+        openModalWithBook(bookId);
+    }
+
+    if (event.target === modal) {
+        closeModal();
+    }
+});
+
+document.addEventListener('keydown', function (event) {
+    if (event.key === "Escape" && modal.style.display === 'block') {
+        closeModal();
+    }
+});

--- a/bookEx/templates/base.html
+++ b/bookEx/templates/base.html
@@ -90,6 +90,6 @@
 </div>
 
 <script src="{% static 'themeToggle.js' %}"></script>
-
+<script src="{% static 'modalHandler.js' %}"></script>
 </body>
 </html>

--- a/bookEx/templates/base.html
+++ b/bookEx/templates/base.html
@@ -65,6 +65,31 @@
 		{% endblock content %}
 	</div>
 </section>
+
+
+<div id="bookDetailModal" class="modal" style="display: none;">
+	<div class="modal-content">
+		<span class="close-button" onclick="closeModal()">×</span>
+		<h2 id="modalBookTitle">Book Title</h2>
+		<div class="modal-body">
+			<div class="modal-image">
+				<img id="modalBookImage" src="" alt="Book Cover" style="max-width: 150px; height: auto;">
+			</div>
+			<div class="modal-details">
+				<p><strong>Price:</strong> $<span id="modalBookPrice">0.00</span></p>
+				<p><strong>Seller:</strong> <span id="modalBookSeller">Seller Name</span></p>
+				<p><strong>Posted:</strong> <span id="modalBookDate">Date</span></p>
+				<p><strong>Website:</strong> <a id="modalBookWeb" href="#" target="_blank" rel="noopener noreferrer">Link</a></p>
+				<div id="modalActionArea" style="margin-top: 15px;">
+				</div>
+				<div id="modalMessages" style="margin-top: 10px;">
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
 <script src="{% static 'themeToggle.js' %}"></script>
+
 </body>
 </html>

--- a/bookEx/templates/bookMng/displayCart.html
+++ b/bookEx/templates/bookMng/displayCart.html
@@ -35,12 +35,13 @@
 					<tr>
 						<td>
 							{% if cart_item.item.picture %}
-								<img src="{{ cart_item.item.picture.url }}" alt="{{ cart_item.item.name }} Cover" style="width: 50px; height: auto;">
+								<a href="#" data-book-id="{{ cart_item.item.id }}"><img src="{{ cart_item.item.picture.url }}" alt="
+								{{ cart_item.item.name }} Cover" style="width: 50px; height: auto;"></a>
 							{% else %}
 								(No image)
 							{% endif %}
 						</td>
-						<td><a href="{% url 'book_detail' cart_item.item.id %}?from=displaycart">{{ cart_item.item.name }}</a></td>
+						<td><a href="#" data-book-id="{{ cart_item.item.id }}">{{ cart_item.item.name }}</a></td>
 						<td>${{ cart_item.item.price|floatformat:2 }}</td>
 						<td>{{ cart_item.item.username.username }}</td>
 						<td>

--- a/bookEx/templates/bookMng/displaybooks.html
+++ b/bookEx/templates/bookMng/displaybooks.html
@@ -29,9 +29,14 @@
 		<tbody id="bookTableBody">
 		{% for book in books %}
 			<tr>
-				<td><a href="book_detail/{{ book.id }}?from=displaybooks"><img src="{{ book.picture.url }}" width="100"
-				                                                               alt="Cover for {{ book.name }}"/></a></td>
-				<td><a href="book_detail/{{ book.id }}?from=displaybooks"> {{ book.name }} </a></td>
+				<td>
+					<a href="#" data-book-id="{{ book.id }}">
+						<img src="{{ book.picture.url }}" width="100" alt="Cover for {{ book.name }}"/>
+					</a>
+				</td>
+				<td>
+					<a href="#" data-book-id="{{ book.id }}"> {{ book.name }} </a>
+				</td>
 				<td>{{ book.price }}</td>
 				<td>{{ book.username.username }}</td>
 			</tr>

--- a/bookEx/templates/bookMng/mybooks.html
+++ b/bookEx/templates/bookMng/mybooks.html
@@ -22,22 +22,21 @@
 				<th>Book Cover</th>
 				<th>Book Name</th>
 				<th>Book Price</th>
-				<th>Action</th>
 			</tr>
 			</thead>
 			<tbody>
 			{% for book in books %}
 				<tr>
-					<td><a href="{% url 'book_detail' book.id %}?from=mybooks"><img src="{{ book.picture.url }}" width="100"
-					                                                                alt="Cover for {{ book.name }}"/></a></td>
-					<td><a href="{% url 'book_detail' book.id %}?from=mybooks"> {{ book.name }} </a></td>
-					<td> {{ book.price }} </td>
 					<td>
-						<a href="{% url 'book_delete' book.id %}" class="button button-danger"
-						   onclick="return confirm('Are you sure you want to delete this book?');">
-							<i class="fas fa-trash-alt"></i> Delete
+						<a href="#" data-book-id="{{ book.id }}">
+							<img src="{{ book.picture.url }}" width="100" alt="Cover for {{ book.name }}"/>
 						</a>
+
 					</td>
+					<td>
+						<a href="#" data-book-id="{{ book.id }}"> {{ book.name }} </a>
+					</td>
+					<td> {{ book.price }} </td>
 				</tr>
 			{% endfor %}
 			</tbody>

--- a/bookMng/urls.py
+++ b/bookMng/urls.py
@@ -7,11 +7,11 @@ urlpatterns = [
     path('displaybooks', views.displaybooks, name='displaybooks'),
     path('booksearch', views.booksearch_ajax, name='booksearch_ajax'),
     path('mybooks', views.mybooks, name='mybooks'),
-    path('book_detail/<int:book_id>', views.book_detail, name='book_detail'),
+    # path('book_detail/<int:book_id>', views.book_detail, name='book_detail'),
     path('book_delete/<int:book_id>', views.book_delete, name='book_delete'),
     path('displayCart', views.displayCart, name='displayCart'),
     path('addtocart/<int:book_id>', views.addtocart, name='addtocart'),
     path('removefromcart/<int:book_id>', views.remove_from_cart, name='removefromcart'),
     path('updatecart', views.update_cart, name='updatecart'),
-
+    path('api/book_detail/<int:book_id>/', views.get_book_detail_json, name='get_book_detail_json'),
 ]


### PR DESCRIPTION
# Modals
- Replace unnecessary book_detail/{book_id} page with a modal that allows user to quickly check book details, delete, add to cart, and any other future features that require action buttons. 
- Clicking out or hitting 'ESC' closes the modal out.
- Buttons only appear for relevant, applicable actions. 
- The delete button only appears if you are the owner of the book.
- Add to cart only appears if the book is from another seller (not yourself).

![CleanShot 2025-04-28 at 12 54 49@2x](https://github.com/user-attachments/assets/07208d04-777a-4934-bdb4-66b37b93a01e)

![CleanShot 2025-04-28 at 12 55 04@2x](https://github.com/user-attachments/assets/c334edc1-84d5-44e9-99d0-d5f67411cb63)
